### PR TITLE
Removed unnecessary title from find stores popup

### DIFF
--- a/src/Components/Chatbot.jsx
+++ b/src/Components/Chatbot.jsx
@@ -536,9 +536,6 @@ const Chatbot = () => {
           >
             <CloseIcon />
           </IconButton>
-          <Typography id="nearest-grocery-modal-title" variant="h6" gutterBottom>
-            Nearest Grocery Stores
-          </Typography>
           <NearestGroceryStore missingIngredients={missingIngredients} />
         </Paper>
       </Modal>


### PR DESCRIPTION
The find stores popup had an unnecessary/redundant h6 title. This has been removed.